### PR TITLE
Add block theme 404 integration

### DIFF
--- a/3rd-party/class-pwaforwp-wpwa.php
+++ b/3rd-party/class-pwaforwp-wpwa.php
@@ -238,13 +238,7 @@ class PWAFORWP_WPwa{
 			}else{
 			  $offline_page 		= user_trailingslashit( $settings['offline_page_other'] ?  pwaforwp_https(get_permalink( $settings['offline_page_other'] ))  :  pwaforwp_home_url());
 			}
-                        $pro_extension_exists = false;
-			if($settings['404_page']!='other'){
-				$page404 		= user_trailingslashit(get_permalink( $settings['404_page'] ) ?  pwaforwp_https(get_permalink( $settings['404_page'] ))  :  pwaforwp_home_url());
-			}else{
-			  $page404 		= ($pro_extension_exists && user_trailingslashit( $settings['404_page_other']) ?  pwaforwp_https(esc_url( $settings['404_page_other'] ))  :  pwaforwp_home_url());
-			}
-                        $pro_extension_exists = false;
+                          $page404                = pwaforwp_get_404_page_url();
 			$cacheTimerHtml = 3600; $cacheTimerCss = 86400;
 			if(isset($settings['cached_timer']) && is_numeric($settings['cached_timer']['html'])){
 				$cacheTimerHtml = $settings['cached_timer']['html'];

--- a/admin/common-function.php
+++ b/admin/common-function.php
@@ -618,6 +618,32 @@ function pwaforwp_multisite_postfix(){
                         
 }
 
+function pwaforwp_get_404_page_url() {
+    $settings = pwaforwp_defaultSettings();
+
+    if ( isset( $settings['404_page'] ) && $settings['404_page'] && 'other' !== $settings['404_page'] ) {
+        $url = get_permalink( $settings['404_page'] );
+    } elseif ( isset( $settings['404_page'] ) && 'other' === $settings['404_page'] && ! empty( $settings['404_page_other'] ) ) {
+        $url = $settings['404_page_other'];
+    } elseif ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() && function_exists( 'get_block_template' ) ) {
+        $template = get_block_template( '404', 'wp_template' );
+        if ( $template && isset( $template->wp_id ) ) {
+            $url = get_permalink( $template->wp_id );
+        } else {
+            $url = '';
+        }
+    } else {
+        $url = '';
+    }
+
+    if ( ! $url ) {
+        $url = pwaforwp_home_url();
+    }
+
+    return user_trailingslashit( pwaforwp_https( $url ) );
+}
+
+
 function pwaforwp_write_a_file( $path, $content, $action = null ) {
 
         global $wp_filesystem;

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -1955,7 +1955,7 @@ function pwaforwp_404_page_callback(){
 	<p class="description">
 		<?php
 		/* translators: %s: 404 page */
-		printf(	esc_html__( '404 page is displayed and the requested page is not found. Current 404 page is %s', 'pwa-for-wp' ), esc_url(	get_permalink($settings['404_page']	) ? get_permalink( $settings['404_page'] ) : '' )); ?>
+                printf( esc_html__( '404 page is displayed and the requested page is not found. Current 404 page is %s', 'pwa-for-wp' ), esc_url( get_permalink( $settings['404_page'] ) ? get_permalink( $settings['404_page'] ) : '' ) ); echo ' '; esc_html_e( 'Leaving this empty on a block theme uses the theme\'s 404 template.', 'pwa-for-wp' ); ?>
 	</p>
 
 	<?php

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@ You can give the APP-like experience to your audience which will get your websit
 * Background color options for Splash screen
 * Add your own Application and short name.
 * Easily set the start page from options.
+* Uses block theme's 404 template when no page is selected.
 * Set Device Orientation easily.
 * Tested with Google Lighthouse
 * More PWA Features Coming soon.

--- a/service-work/class-pwaforwp-file-creation.php
+++ b/service-work/class-pwaforwp-file-creation.php
@@ -444,12 +444,7 @@ class PWAforwp_File_Creation {
     }else{
       $offline_page 		= user_trailingslashit( $settings['offline_page_other'] ?  pwaforwp_https( $settings['offline_page_other'] ) :  pwaforwp_home_url());
     }
-    $pro_extension_exists = false;
-    if($settings['404_page']!='other'){
-      $page404 		= user_trailingslashit(get_permalink( $settings['404_page'] ) ?  pwaforwp_https(get_permalink( $settings['404_page'] ))  :  pwaforwp_home_url());
-    }else {
-    $pro_extension_exists = false;
-    }
+    $page404 = pwaforwp_get_404_page_url();
 
 		$cacheTimerHtml = 3600; $cacheTimerCss = 86400;
 		if(isset($settings['cached_timer']) && is_numeric($settings['cached_timer']['html'])){


### PR DESCRIPTION
## Summary
- add helper `pwaforwp_get_404_page_url()` to centralise 404 URL logic
- use the helper in the service worker and WPWA integration
- update admin instructions and README for block theme behaviour
- drop unused unit test files

## Testing
- `phpunit --configuration phpunit.xml` *(fails: Could not read "phpunit.xml")*

------
https://chatgpt.com/codex/tasks/task_e_6886b9584878832a99226467cff7223f