### PR TITLE
Fix PHP tag for settings hook

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -200,9 +200,9 @@ function pwaforwp_admin_interface_render()
                 </form>
 
             </div>
-    WP Settings API
-*/
-add_action('admin_init', 'pwaforwp_settings_init');
+    <?php
+    /* WP Settings API */
+    add_action('admin_init', 'pwaforwp_settings_init');
 
 function pwaforwp_settings_init(){
     $settings = pwaforwp_defaultSettings(); 


### PR DESCRIPTION
## Summary
- ensure the Settings API hook executes by re-entering PHP mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887409b381c832aa2704ec6cb8941f9