### PR TITLE
Fix closing tag and update display description

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -200,9 +200,10 @@ function pwaforwp_admin_interface_render()
                 </form>
 
             </div>
-    <?php
-    /* WP Settings API */
-    add_action('admin_init', 'pwaforwp_settings_init');
+<?php
+} // end pwaforwp_admin_interface_render
+/* WP Settings API */
+add_action('admin_init', 'pwaforwp_settings_init');
 
 function pwaforwp_settings_init(){
     $settings = pwaforwp_defaultSettings(); 
@@ -2181,7 +2182,6 @@ function pwaforpw_orientation_callback()
         <?php echo esc_html__( 'Orientation of application on devices. When set to Follow Device Orientation your application will rotate as the device is rotated.', 'pwa-for-wp' ); ?>
     </p>
 
-    <?php
 }
 
 function pwaforpw_display_callback()
@@ -2215,9 +2215,8 @@ function pwaforpw_display_callback()
             </option>
         </select>
     </label>
-    
     <p class="description">
-        <?php echo esc_html__( 'Orientation of application on devices. When set to Follow Device Orientation your application will rotate as the device is rotated.', 'pwa-for-wp' ); ?>
+        <?php echo esc_html__( 'Select how the app should appear when launched from the home screen (fullscreen, standalone, minimal-ui, or browser).', 'pwa-for-wp' ); ?>
     </p>
 
     <?php


### PR DESCRIPTION
## Summary
- properly close `pwaforwp_admin_interface_render()` in `settings.php`
- clarify display mode option description

## Testing
- `php -l admin/settings.php`

------
https://chatgpt.com/codex/tasks/task_e_6887808729d0832a8dcde9f574d1c274