### PR TITLE
Remove legacy push notification integrations

### DIFF
--- a/admin/class-pwaforwp-utility.php
+++ b/admin/class-pwaforwp-utility.php
@@ -28,29 +28,6 @@ class PWAFORWP_Utility{
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 	    $currentActivateModule = sanitize_text_field( wp_unslash($_REQUEST['activate']));
 
-	    switch($currentActivateModule){
-
-	    	case 'pushnotification': 
-
-	            $nonceUrl = add_query_arg(
-	                                    array(
-	                                        'action'        => 'activate',
-	                                        'plugin'        => 'push-notification',
-	                                        'plugin_status' => 'all',
-	                                        'paged'         => '1',
-	                                        '_wpnonce'      => wp_create_nonce( 'activate-plugin_push-notification' ),
-	                                    ),
-	                        esc_url(network_admin_url( 'plugins.php' ))
-	                        );
-	            $plugins[] = array(
-	                            'name' => 'push-notification',
-	                            'path_' => 'https://downloads.wordpress.org/plugin/push-notification.zip',
-	                            'path' => $nonceUrl,
-	                            'install' => 'push-notification/push-notification.php',
-	                        );
-	            $redirectSettingsUrl = admin_url('admin.php?page=push-notification&reference=pwaforwp');
-	        break;
-	    }
 
 	    if(count($plugins)>0){
 	       echo wp_json_encode( array( "status"=>200, "message"=>esc_html__("Module successfully Added",'pwa-for-wp'),'redirect_url'=>esc_url($redirectSettingsUrl) , "slug"=>$plugins[0]['name'], 'path'=> $plugins[0]['path'] ) );

--- a/admin/common-function.php
+++ b/admin/common-function.php
@@ -321,7 +321,6 @@ function pwaforwp_fields_and_type($data_type = 'value'){
         'normal_enable'         => array('type'=>'checkbox','value'=>1),
         'amp_enable'            => array('type'=>'checkbox','value'=>1),
         'cached_timer'          => array('type'=>'text','value'=>array('html'=>3600,'css'=>86400)),
-        'serve_js_cache_menthod'=> array('type'=>'checkbox','value'=>false),
         'default_caching'       => array('type'=>'text','value'=>'cacheFirst'),
         'default_caching_js_css'=> array('type'=>'text','value'=>'cacheFirst'),
         'default_caching_images'=> array('type'=>'text','value'=>'cacheFirst'),
@@ -622,13 +621,9 @@ function pwaforwp_delete_pwa_files() {
 
 function pwaforwp_required_file_creation( $action = null) {
     
-    $settings = pwaforwp_defaultSettings(); 
-
-    $server_key = $config = '';       
 
     $fileCreationInit = new PWAFORWP_File_Creation_Init();
 
-    // Removed push notification integrations
                             
     $status = '';                    
     $status = $fileCreationInit->pwaforwp_swjs_init( $action );
@@ -742,7 +737,7 @@ function pwaforwp_service_workerUrls($url, $filename){
   $home_url       = pwaforwp_home_url();  
 
 
-  if( ( !pwaforwp_is_file_inroot() || $site_url!= $home_url) && !class_exists( 'WPPushnami' ) ){
+  if( ( !pwaforwp_is_file_inroot() || $site_url!= $home_url) ){
 	  $filename = str_replace(".", "-", $filename);
       $home_url = rtrim($home_url, "/");
       $home_url = add_query_arg(pwaforwp_query_var('sw_query_var'), 1, $home_url);
@@ -750,9 +745,6 @@ function pwaforwp_service_workerUrls($url, $filename){
       $url = $home_url;
   }
   
-  if(isset($settings['serve_js_cache_menthod']) && $settings['serve_js_cache_menthod']=='true'){
-    $url = esc_url_raw(admin_url( 'admin-ajax.php?action=pwaforwp_sw_files&'.pwaforwp_query_var('sw_query_var').'=1&'.pwaforwp_query_var('sw_file_var').'='.$filename ));
-  }
   return $url;
 }
 
@@ -1260,24 +1252,6 @@ function pwaforwp_local_file_get_contents( $file_path ) {
 
 }
 
-add_filter('pwaforwp_sw_register_template', 'pwaforwp_sw_register_apk_detect', 10, 1);
-
-function pwaforwp_sw_register_apk_detect($sw_template){
-
-    $pwaSettings = pwaforwp_defaultSettings();
-        if( $pwaSettings['notification_feature']==1 && isset($pwaSettings['notification_options']) && $pwaSettings['notification_options']=='pushnotifications_io'){
-            $sw_template .="	document.addEventListener('DOMContentLoaded', function () {
-                if (typeof pnScriptSetting !== 'undefined' && pnScriptSetting.pwaforwp_apk_only !== undefined && pnScriptSetting.pwaforwp_apk_only == 1) {
-                    const reffer = document.referrer; 
-                    if (reffer && reffer.includes('android-app://')) {
-                        sessionStorage.setItem('pwaforwp_mode', 'apk');
-                    }
-                }
-            });"; 
-        }
-    
-    return $sw_template;
-}
 
 function custom_pwaforwp_whitelabel_title($title) {
     $config_file_path = ABSPATH . 'pwa-config.php';

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -510,13 +510,6 @@ function pwaforwp_settings_init(){
 			'pwaforwp_other_setting_section'						// Settings Section ID
 		);
 		add_settings_field(
-			'pwaforwp_serve_cache_method_setting',							// ID
-			'<label for="pwaforwp_settings[serve_js_cache_menthod]"><b>'.esc_html__('PWA alternative method', 'pwa-for-wp').'</b></label>',	// Title
-			'pwaforwp_serve_cache_method_setting_callback',							// CB
-			'pwaforwp_other_setting_section',						// Page slug
-			'pwaforwp_other_setting_section'						// Settings Section ID
-		);
-		add_settings_field(
 			'pwaforwp_reset_cookies_method_setting',							// ID
 			'<label for="pwaforwp_settings[reset_cookies]"><b>'.esc_html__('Reset cookies','pwa-for-wp').'</b></label>',	// Title
 			'pwaforwp_reset_cookies_method_setting_callback',							// CB
@@ -820,14 +813,6 @@ function pwaforwp_swipe_navigation_setting_callback(){
 	<?php
 }
 
-function pwaforwp_serve_cache_method_setting_callback(){
-	// Get Settings
-	$settings = pwaforwp_defaultSettings(); 
-	?>
-	<input type="checkbox" name="pwaforwp_settings[serve_js_cache_menthod]" id="pwaforwp_settings[serve_js_cache_menthod]" class=""  <?php echo (isset( $settings['serve_js_cache_menthod'] ) && $settings['serve_js_cache_menthod']=='true'? esc_attr('checked') : ''); ?> data-uncheck-val="0" value="true">
-	<p><?php echo esc_html__('Enable(check) it when PWA with OneSignal or root permission functionality not working because of Cache','pwa-for-wp'); ?></p>
-	<?php
-}
 
 function pwaforwp_reset_cookies_method_setting_callback(){
 	// Get Settings
@@ -2521,18 +2506,6 @@ function pwaforwp_send_query_message(){
                                     'slug' => 'ofpwa',
                                     'tooltip_option'=> esc_html__('It auto saves the data on the fly', 'pwa-for-wp'),
 									'tooltip_link'	=> 'https://pwa-for-wp.com/docs/article/how-to-use-auto-save-forms/'
-                                    ),
-				'buddypress_notification' => array(
-                                    'enable_field' => esc_html__('buddypress_notification', 'pwa-for-wp'),
-                                    'section_name' => esc_html__('pwaforwp_buddypress_setting_section', 'pwa-for-wp'),
-                                    'setting_title' => esc_html__('Buddypress', 'pwa-for-wp'),
-                                    'is_premium'    => true,
-                                    'pro_link'      => $addonLists['bnpwa']['p-url'],
-                                    'pro_active'    => (is_plugin_active($addonLists['bnpwa']['p-slug'])? 1: 0),
-                                    'pro_deactive'    => (!is_plugin_active($addonLists['bnpwa']['p-slug']) && file_exists(PWAFORWP_PLUGIN_DIR."/../".$addonLists['bnpwa']['p-slug'])? 1: 0),
-                                    'slug' => 'bnpwa',
-                                    'tooltip_option'=> esc_html__('Support buddypress push notification with PWA and push notification', 'pwa-for-wp'),
-                                    'tooltip_link' => 'https://pwa-for-wp.com/docs/article/how-to-use-buddypress-for-pwaforwp/'
                                     ),
 				'quickaction' => array(
 									'enable_field' => esc_html__('quick_action', 'pwa-for-wp'),

--- a/service-work/class-pwaforwp-file-creation-init.php
+++ b/service-work/class-pwaforwp-file-creation-init.php
@@ -75,33 +75,6 @@ class PWAFORWP_File_Creation_Init {
         return pwaforwp_write_a_file($this->swhtml_init_amp, $swHtmlContent, $action);
                  
     }
-    public function pwaforwp_swhtml_init_firebase_js($action = null){  
-        
-        $settings 	= pwaforwp_defaultSettings(); 
-        
-        $server_key     = $settings['fcm_server_key'];
-        $config         = $settings['fcm_config'];
-                                
-        $swjsContent    = $this->fileCreation->pwaforwp_swjs();
-        $status         = pwaforwp_write_a_file($this->swjs_init, $swjsContent, $action);
-                
-        $swjsContent    = $this->fileCreation->pwaforwp_swr();
-        $status         = pwaforwp_write_a_file($this->swr_init, $swjsContent, $action);
-        
-
-        //Dummy file to work FCM perfectly 
-        
-        if($server_key !='' && $config !=''){
-
-            $pn_sw_js       = $this->wppath."firebase-messaging-sw.js";  
-            $swjsContent    = '';
-            $status         =  pwaforwp_write_a_file($pn_sw_js, $swjsContent, $action);
-        
-        }
-                
-        return $status;
-                                
-    }    
 }
 
 add_action('wp_ajax_pwaforwp_download_setup_files', 'pwaforwp_download_setup_files');

--- a/service-work/class-pwaforwp-service-worker.php
+++ b/service-work/class-pwaforwp-service-worker.php
@@ -101,37 +101,6 @@ class PWAFORWP_Service_Worker {
                 @header( 'Content-Type: application/javascript; charset=utf-8' );
                 // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- we are not processing form here
                 $fileRawName = $filename =  sanitize_file_name($_GET[pwaforwp_query_var('sw_file_var')]);
-                if($filename == 'dynamic_onesignal' || in_array($filename, array('OneSignalSDKWorker-'.get_current_blog_id().'.js.php', 'OneSignalSDKWorker-'.get_current_blog_id().'.js_.php')) ){//work with onesignal only
-                    $filename = str_replace(".js_",".js", $filename);
-                    if(file_exists(ABSPATH.$filename)){
-                        require_once ABSPATH.$filename;
-                    }
-
-                    header("Service-Worker-Allowed: /");
-                    header("Content-Type: application/javascript");
-                    header("X-Robots-Tag: none");
-                    exit;
-                }elseif($filename == 'dynamic_pushnami'){//work with pushnami only
-                    $home_url = pwaforwp_home_url();
-                    // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- we are not processing form here
-                    $site_id = sanitize_text_field( $_GET[ pwaforwp_query_var('site_id_var') ] );
-                    if($site_id=='normal'){ $site_id = ''; }else{ $site_id = "-".$site_id; }
-
-                    $pn_options = \WPPushnami::get_script_options();
-                    $pn_api_key = $pn_options->api_key;
-
-                    $url = ($home_url.'?'.pwaforwp_query_var('sw_query_var').'=1&'.pwaforwp_query_var('sw_file_var').'='.'pwa-sw'.$site_id.'-js');
-                    $url = pwaforwp_service_workerUrls($url, 'pwa-sw'.$site_id.'-js');
-                    header("Service-Worker-Allowed: /");
-                    header("Content-Type: application/javascript");
-                    header("X-Robots-Tag: none");
-                    $content_escaped .= "importScripts('".esc_js($url)."')".PHP_EOL;
-                    $content_escaped .= "importScripts('https://api.pushnami.com/scripts/v2/pushnami-sw/".esc_js($pn_api_key)."')".PHP_EOL;
-                    $content_escaped = preg_replace('/\s+/', ' ', $content_escaped);
-                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped	-- already escaped all contents
-                    echo $content_escaped; 
-                    exit;
-                }
                 if( strrpos($filename, '-js', -3) !== false ){
                     $filename = str_replace("-js", ".js", $filename);
                 }if( strrpos($filename, '-html', -5) !== false ){
@@ -197,32 +166,6 @@ class PWAFORWP_Service_Worker {
                 @header( 'Cache-Control: no-cache' );
                 @header( 'Content-Type: application/javascript; charset=utf-8' );
                 $fileRawName = $filename = sanitize_file_name( $query->get( pwaforwp_query_var('sw_file_var') ) );
-               if($filename == 'dynamic_onesignal' || in_array($filename, array('OneSignalSDKWorker-'.get_current_blog_id().'.js.php', 'OneSignalSDKWorker-'.get_current_blog_id().'.js_.php')) ){//work with onesignal only
-                    $filename = str_replace(".js_",".js", $filename);
-                    if(file_exists(ABSPATH.$filename)){
-                        require_once ABSPATH.$filename;
-                    }
-
-                    header("Service-Worker-Allowed: /");
-                    header("Content-Type: application/javascript");
-                    header("X-Robots-Tag: none");
-                    exit;
-                }elseif($filename == 'dynamic_pushnami'){//work with pushnami only
-                    $home_url = pwaforwp_home_url();
-                    $site_id = sanitize_text_field( $query->get( pwaforwp_query_var('site_id_var') ) );
-                    if($site_id=='normal'){ $site_id = ''; }else{ $site_id = "-".$site_id; }
-
-                    $url = ($home_url.'?'.pwaforwp_query_var('sw_query_var').'=1&'.pwaforwp_query_var('sw_file_var').'='.'pwa-sw'.$site_id.'-js');
-                    header("Service-Worker-Allowed: /");
-                    header("Content-Type: application/javascript");
-                    header("X-Robots-Tag: none");
-                    $content_escaped .= "importScripts('".esc_js($url)."')".PHP_EOL;
-                    $content_escaped .= "importScripts('https://api.pushnami.com/scripts/v2/pushnami-sw/".esc_js($pn_api_key)."')".PHP_EOL;
-                    $content_escaped = preg_replace('/\s+/', ' ', $content_escaped);
-                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped	-- already escaped all contents
-                    echo $content_escaped;
-                    exit;
-                }
                 if( strrpos($filename, '-js', -3) !== false ){
                     $filename = str_replace("-js", ".js", $filename);
                     header("Service-Worker-Allowed: /");


### PR DESCRIPTION
## Summary
- drop obsolete push notification settings and defaults
- remove push worker generation code and third-party checks
- delete legacy utility logic for push notification module

## Testing
- `php -l admin/class-pwaforwp-utility.php`
- `php -l admin/common-function.php`
- `php -l admin/settings.php`
- `php -l service-work/class-pwaforwp-file-creation-init.php`
- `php -l service-work/class-pwaforwp-service-worker.php`


------
https://chatgpt.com/codex/tasks/task_e_689138397674832aad590a9acb0f41d0